### PR TITLE
feat: update PowerDNS to v5 and Debian trixi

### DIFF
--- a/docker/ddns/Dockerfile
+++ b/docker/ddns/Dockerfile
@@ -8,8 +8,11 @@ COPY . .
 RUN GO111MODULE=on go get -d -v ./...
 RUN GO111MODULE=on go install -v ./...
 
-ENV GIN_MODE release
-ENV DDNS_EXPIRATION_DAYS 10
+ENV GIN_MODE=release
+ENV DDNS_EXPIRATION_DAYS=10
+
+EXPOSE 8080
+EXPOSE 8053
 
 CMD /go/bin/ddns \
     --domain=${DDNS_DOMAIN} \

--- a/docker/docker-compose.override.yml.sample
+++ b/docker/docker-compose.override.yml.sample
@@ -1,5 +1,3 @@
-version: '2'
-
 services:
   ddns:
     environment:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '2'
-
 services:
   ddns:
     restart: unless-stopped
@@ -25,4 +23,4 @@ services:
 
   redis:
     restart: unless-stopped
-    image: redis:4-alpine
+    image: redis:6-alpine

--- a/docker/powerdns/Dockerfile
+++ b/docker/powerdns/Dockerfile
@@ -1,11 +1,11 @@
-FROM buildpack-deps:stretch-scm
+FROM buildpack-deps:trixie-curl
 
 # the setup procedure according to https://repo.powerdns.com/ (Debian 9 Stretch)
-RUN echo "deb [arch=amd64] http://repo.powerdns.com/debian stretch-auth-43 main" > /etc/apt/sources.list.d/pdns.list \
-	&& echo "Package: pdns-*\nPin: origin repo.powerdns.com\nPin-Priority: 600\n" >> /etc/apt/preferences.d/pdns \
-	&& curl https://repo.powerdns.com/FD380FBB-pub.asc | apt-key add - \
-	&& apt-get -y update \
-	&& apt-get install -y pdns-server pdns-backend-remote \
+RUN echo "deb [signed-by=/etc/apt/keyrings/auth-50-pub.asc] http://repo.powerdns.com/debian trixie-auth-50 main" > /etc/apt/sources.list.d/pdns.list \
+    && echo "Package: pdns-*\nPin: origin repo.powerdns.com\nPin-Priority: 600\n" >> /etc/apt/preferences.d/pdns \
+    && install -d /etc/apt/keyrings; curl https://repo.powerdns.com/FD380FBB-pub.asc | tee /etc/apt/keyrings/auth-50-pub.asc \
+    && apt-get -y update \
+    && apt-get install -y pdns-server pdns-backend-remote \
 	&& rm -rf /var/lib/apt/lists/*
 
 COPY pdns.conf /etc/powerdns/pdns.conf

--- a/docker/powerdns/pdns.conf
+++ b/docker/powerdns/pdns.conf
@@ -2,6 +2,7 @@ cache-ttl=0
 loglevel=7
 log-dns-details=yes
 disable-axfr=yes
+zone-cache-refresh-interval=0
 
 launch=remote
 remote-dnssec=no


### PR DESCRIPTION
Update to PowerDNS v5 and Debian trixi

Updated docker/powerdns/Dockerfile for this.

With PowerDNS v4.5 was made the filling-zone-cache on startup default behaviour, except zone-cache is set to 0. Due to that PowerDNS was not starting up, since backend is not supporting the getAllDomains method.