### PR TITLE
feat: replace zone cache zero

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,6 @@
 dump.rdb
 /docker/.caddy_mount/
 /docker/.redis_mount/
+/docker/docker-compose.override.yml
 
 .idea

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 dump.rdb
 /docker/.caddy_mount/
 /docker/.redis_mount/
+
+.idea

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -1,10 +1,11 @@
 package backend
 
 import (
-	"github.com/gin-gonic/gin"
-	"github.com/pboehm/ddns/shared"
 	"log"
 	"strings"
+
+	"github.com/gin-gonic/gin"
+	"github.com/pboehm/ddns/shared"
 )
 
 type Backend struct {
@@ -58,6 +59,12 @@ func (b *Backend) Run() error {
 	r.GET("/dnsapi/getAllDomainMetadata/:name", func(c *gin.Context) {
 		c.JSON(200, gin.H{
 			"result": gin.H{"PRESIGNED": []string{"0"}},
+		})
+	})
+
+	r.GET("/dnsapi/getAllDomains", func(c *gin.Context) {
+		c.JSON(200, gin.H{
+			"result": gin.H{"zone": b.config.SOAFqdn},
 		})
 	})
 

--- a/backend/lookup_test.go
+++ b/backend/lookup_test.go
@@ -2,9 +2,10 @@ package backend
 
 import (
 	"errors"
+	"testing"
+
 	"github.com/pboehm/ddns/shared"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 type testHostBackend struct {

--- a/ddns.go
+++ b/ddns.go
@@ -1,11 +1,12 @@
 package main
 
 import (
+	"log"
+
 	"github.com/pboehm/ddns/backend"
 	"github.com/pboehm/ddns/frontend"
 	"github.com/pboehm/ddns/shared"
 	"golang.org/x/sync/errgroup"
-	"log"
 )
 
 var serviceConfig *shared.Config = &shared.Config{}

--- a/docker/powerdns/pdns.conf
+++ b/docker/powerdns/pdns.conf
@@ -2,7 +2,6 @@ cache-ttl=0
 loglevel=7
 log-dns-details=yes
 disable-axfr=yes
-zone-cache-refresh-interval=0
 
 launch=remote
 remote-dnssec=no

--- a/frontend/frontend.go
+++ b/frontend/frontend.go
@@ -2,13 +2,14 @@ package frontend
 
 import (
 	"fmt"
-	"github.com/gin-gonic/gin"
-	"github.com/pboehm/ddns/shared"
 	"html/template"
 	"log"
 	"net"
 	"net/http"
 	"regexp"
+
+	"github.com/gin-gonic/gin"
+	"github.com/pboehm/ddns/shared"
 )
 
 type Frontend struct {

--- a/shared/redis.go
+++ b/shared/redis.go
@@ -2,8 +2,9 @@ package shared
 
 import (
 	"errors"
-	"github.com/garyburd/redigo/redis"
 	"time"
+
+	"github.com/garyburd/redigo/redis"
 )
 
 type RedisBackend struct {


### PR DESCRIPTION
Did some sorting of the inputs as started in #2 

Other than that a basic functionality of zone cache filling for powerdns (route /getAllDomains )
PowerDNS expects at startup since v4.5 at least one zone from HTTP Endpoint /dnsapi/getAllDomains. The function now returns the zone of the master dydns Domain specified in the ENV Variable.